### PR TITLE
Use errno module instead of inline constant

### DIFF
--- a/lib/configstore.js
+++ b/lib/configstore.js
@@ -14,7 +14,7 @@ function readFile(filePath) {
 		return fs.readFileSync(filePath, 'utf8');
 	} catch (err) {
 		// Create dir if it doesn't exist
-		if (err.errno === 34) {
+		if (err.code === 'ENOENT') {
 			mkdirp.sync(path.dirname(filePath));
 			return '';
 		}


### PR DESCRIPTION
I don't like numeric constants and `errno` provide a nice readable way to look up the string representation instead.
