### PR TITLE
Correct use of XDG_CONFIG_HOME

### DIFF
--- a/lib/configstore.js
+++ b/lib/configstore.js
@@ -5,8 +5,9 @@ var _ = require('lodash');
 var mkdirp = require('mkdirp');
 var YAML = require('yamljs');
 
-var homeDir = process.env.XDG_CONFIG_HOME ||
-	process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'];
+var configDir = process.env.XDG_CONFIG_HOME ||
+	path.join(process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'],
+			  '.config');
 
 
 function readFile(filePath) {
@@ -22,7 +23,7 @@ function readFile(filePath) {
 }
 
 function Configstore(id, defaults) {
-	this.path = path.join(homeDir, '.config', 'configstore', id + '.yml');
+	this.path = path.join(configDir, 'configstore', id + '.yml');
 	this.all = _.extend({}, defaults, this.all);
 }
 


### PR DESCRIPTION
From the [XDG Base Dir Spec](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html):

> $XDG_CONFIG_HOME defines the base directory relative to which user specific configuration files should be stored. If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.

Previously, if $XDG_CONFIG_HOME was not set, the config path defaulted to `$HOME/.config/configstore`. However, if $XDG_CONFIG_HOME was set to a valid value like `$HOME/.config` the path would have expanded to `$HOME/.config/.config/configstore`.
