### PR TITLE
Rethrow error

### DIFF
--- a/configstore.js
+++ b/configstore.js
@@ -20,6 +20,9 @@ function readFile(filePath) {
 			mkdirp.sync(path.dirname(filePath));
 			return '';
 		}
+		
+		// Rethrow the error
+		throw err;
 	}
 }
 


### PR DESCRIPTION
If the error code is something else than `ENOENT` (e.g.: `EPERM`), readFile should actually rethrow the error.
