### PR TITLE
Generate a fake user if osenv.user() returns null.

### DIFF
--- a/configstore.js
+++ b/configstore.js
@@ -1,6 +1,7 @@
 'use strict';
 var path = require('path');
 var fs = require('fs');
+var crypto = require('crypto');
 var os = require('os');
 var osenv = require('osenv');
 var EOL = os.EOL;
@@ -8,9 +9,14 @@ var _ = require('lodash');
 var mkdirp = require('mkdirp');
 var yaml = require('js-yaml');
 
-var user = (osenv.user() || 'unknown').replace(/\\/g, '-');
+var user = (osenv.user() || generateFakeUser()).replace(/\\/g, '-');
 var tmpDir = path.join(os.tmpdir ? os.tmpdir() : os.tmpDir(), user);
 var configDir = process.env.XDG_CONFIG_HOME || path.join(osenv.home() || tmpDir, '.config');
+
+function generateFakeUser() {
+    var uid = process.pid + '-' + Date.now() + '-' + Math.floor(Math.random() * 1000000);
+    return crypto.createHash('md5').update(uid).digest('hex');
+}
 
 function permissionError() {
 	return 'You don\'t have access to this file.';


### PR DESCRIPTION
I've applied this same strategy to `bower-config`, because some users were complaining about EPERM errors on the `unknown` folder.
