### PR TITLE
Support node 0.8 which has os.tmpDir with different capitalization

### DIFF
--- a/configstore.js
+++ b/configstore.js
@@ -7,9 +7,10 @@ var assign = require('object-assign');
 var mkdirp = require('mkdirp');
 var yaml = require('js-yaml');
 var uuid = require('uuid');
+var getTempDir = os.tmpdir || os.tmpDir; //support node 0.8
 
 var user = (osenv.user() || uuid.v4()).replace(/\\/g, '');
-var tmpDir = path.join(os.tmpdir(), user);
+var tmpDir = path.join(getTempDir(), user);
 var configDir = process.env.XDG_CONFIG_HOME || path.join(osenv.home() || tmpDir, '.config');
 var permissionError = 'You don\'t have access to this file.';
 


### PR DESCRIPTION
A simple change to support node 0.8 which does not have `os.tmpdir`
