### PR TITLE
Add clear function

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,4 +86,8 @@ Configstore.prototype.del = function (key) {
 	this.all = config;
 };
 
+Configstore.prototype.clear = function () {
+	this.all = {};
+}
+
 module.exports = Configstore;

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,10 @@ Get an item.
 
 Delete an item.
 
+### .clear()
+
+Delete all items.
+
 ### .all
 
 Get all items as an object or replace the current config with an object:

--- a/test.js
+++ b/test.js
@@ -21,6 +21,13 @@ it('.del()', function () {
 	assert.notEqual(this.conf.get('foo'), 'bar');
 });
 
+it('.clear()', function(){
+	this.conf.set('foo', 'bar');
+	this.conf.set('foo1', 'bar1');
+	this.conf.clear();
+	assert.equal(this.conf.size, 0);
+});
+
 it('.all', function () {
 	this.conf.set('foo', 'bar');
 	assert.equal(this.conf.all.foo, 'bar');


### PR DESCRIPTION
The function `clear` will empty the configstore, and prepare it for re-population from the beginning.

(I used it in an application, and added it here too.)

Please take a decision as to whether this is required or not.