### PR TITLE
Support for the useGlobalConfigNamespace option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,15 @@ var permissionError = 'You don\'t have access to this file.';
 var defaultPathMode = parseInt('0700', 8);
 var writeFileOptions = {mode: parseInt('0600', 8)};
 
-function Configstore(id, defaults) {
-	this.path = path.join(configDir, 'configstore', id + '.json');
+function Configstore(id, defaults, opts) {
+	opts = opts || {};
+
+	opts.useGlobalConfigNamespace = opts.useGlobalConfigNamespace || false;
+	opts.pathPrefix = opts.useGlobalConfigNamespace ?
+		path.join(id, 'config.json') :
+		path.join('configstore', id + '.json');
+	this.path = path.join(configDir, opts.pathPrefix);
+
 	this.all = assign({}, defaults || {}, this.all || {});
 }
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var writeFileOptions = {mode: parseInt('0600', 8)};
 function Configstore(id, defaults, opts) {
 	opts = opts || {};
 
-	var pathPrefix = opts.useGlobalConfigNamespace ?
+	var pathPrefix = opts.globalConfigPath ?
 		path.join(id, 'config.json') :
 		path.join('configstore', id + '.json');
 	this.path = path.join(configDir, pathPrefix);

--- a/index.js
+++ b/index.js
@@ -18,11 +18,10 @@ var writeFileOptions = {mode: parseInt('0600', 8)};
 function Configstore(id, defaults, opts) {
 	opts = opts || {};
 
-	opts.useGlobalConfigNamespace = opts.useGlobalConfigNamespace || false;
-	opts.pathPrefix = opts.useGlobalConfigNamespace ?
+	var pathPrefix = opts.useGlobalConfigNamespace ?
 		path.join(id, 'config.json') :
 		path.join('configstore', id + '.json');
-	this.path = path.join(configDir, opts.pathPrefix);
+	this.path = path.join(configDir, pathPrefix);
 
 	this.all = assign({}, defaults || {}, this.all || {});
 }

--- a/readme.md
+++ b/readme.md
@@ -26,23 +26,38 @@ console.log(conf.get('awesome'));  // undefined
 
 ## API
 
-### .set(key, value)
+```js
+var Configstore = require('configstore');
+```
+
+### var config = new Configstore(pkg, defaults={}, opts={})
+
+Create a new configstore instance `config`.
+
+`pkg` is the name of your Node package. `defaults` is a map with default values
+of keys that do not yet exist in the configuration file.
+
+`opts` is a map of creation-time options. When the boolean `globalConfigPath` is
+set, the configuration JSON file will be stored at `$CONFIG/pkg/config.json` as
+opposed to the default `$CONFIG/configstore/pkg.json`.
+
+### config.set(key, value)
 
 Set an item.
 
-### .get(key)
+### config.get(key)
 
 Get an item.
 
-### .del(key)
+### config.del(key)
 
 Delete an item.
 
-### .clear()
+### config.clear()
 
 Delete all items.
 
-### .all
+### config.all
 
 Get all items as an object or replace the current config with an object:
 
@@ -52,11 +67,11 @@ conf.all = {
 };
 ```
 
-### .size
+### config.size
 
 Get the item count.
 
-### .path
+### config.path
 
 Get the path to the config file. Can be used to show the user where the config file is located or even better open it for them.
 

--- a/test.js
+++ b/test.js
@@ -49,6 +49,11 @@ it('should use default value', function () {
 	assert.equal(conf.get('foo'), 'bar');
 });
 
+it('support global namespace path option', function () {
+	var conf = new Configstore('configstore-test', {}, {useGlobalConfigNamespace: true});
+	assert(conf.path.endsWith('configstore-test/config.json'));
+});
+
 it('make sure `.all` is always an object', function () {
 	fs.unlinkSync(configstorePath);
 	assert.doesNotThrow(function () {

--- a/test.js
+++ b/test.js
@@ -50,7 +50,7 @@ it('should use default value', function () {
 });
 
 it('support global namespace path option', function () {
-	var conf = new Configstore('configstore-test', {}, {useGlobalConfigNamespace: true});
+	var conf = new Configstore('configstore-test', {}, {globalConfigPath: true});
 	var regex = /configstore-test\/config.json$/;
 	assert(regex.test(conf.path));
 });

--- a/test.js
+++ b/test.js
@@ -51,7 +51,8 @@ it('should use default value', function () {
 
 it('support global namespace path option', function () {
 	var conf = new Configstore('configstore-test', {}, {useGlobalConfigNamespace: true});
-	assert(conf.path.endsWith('configstore-test/config.json'));
+	var regex = /configstore-test\/config.json$/;
+	assert(regex.test(conf.path));
 });
 
 it('make sure `.all` is always an object', function () {


### PR DESCRIPTION
This exposes an options object in the configstore constructor, which will check for the existence of the `useGlobalConfigNamespace` flag. When `true`, the path `.config/package/config.json` is used over `.config/configstore/package.json`.