### PR TITLE
Fix global namespace test so it will work on Windows

### DIFF
--- a/test.js
+++ b/test.js
@@ -51,7 +51,7 @@ it('should use default value', function () {
 
 it('support global namespace path option', function () {
 	var conf = new Configstore('configstore-test', {}, {globalConfigPath: true});
-	var regex = /configstore-test\/config.json$/;
+	var regex = /configstore-test(\/|\\)config.json$/;
 	assert(regex.test(conf.path));
 });
 


### PR DESCRIPTION
The test assumed that file paths use `/` as path delimiter, so it failed on Windows where the delimiter is `\`. I changed the regex to allow both.