### PR TITLE
Pass options object to makeDir.sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const uniqueString = require('unique-string');
 
 const configDir = xdgBasedir.config || path.join(os.tmpdir(), uniqueString());
 const permissionError = 'You don\'t have access to this file.';
-const defaultPathMode = 0o0700;
+const makeDirOptions = {mode: 0o0700};
 const writeFileOptions = {mode: 0o0600};
 
 class Configstore {
@@ -30,7 +30,7 @@ class Configstore {
 		} catch (err) {
 			// Create dir if it doesn't exist
 			if (err.code === 'ENOENT') {
-				makeDir.sync(path.dirname(this.path), defaultPathMode);
+				makeDir.sync(path.dirname(this.path), makeDirOptions);
 				return {};
 			}
 
@@ -51,7 +51,7 @@ class Configstore {
 	set all(val) {
 		try {
 			// Make sure the folder exists as it could have been deleted in the meantime
-			makeDir.sync(path.dirname(this.path), defaultPathMode);
+			makeDir.sync(path.dirname(this.path), makeDirOptions);
 
 			writeFileAtomic.sync(this.path, JSON.stringify(val, null, '\t'), writeFileOptions);
 		} catch (err) {


### PR DESCRIPTION
This PR wraps the value of `defaultPathMode` in an options object. `configstore` [originally used](https://github.com/yeoman/configstore/commit/a4067fd815d9290e43f456221c09c4a93df12708#diff-168726dbe96b3ce427e7fedce31bb0bcR33) `mkdirp.sync` which [supports](https://github.com/substack/node-mkdirp#mkdirpsyncdir-opts) passing the file mode directly in place of the `opts` argument. `makeDir.sync` [does not support](https://github.com/sindresorhus/make-dir/blob/master/index.js#L55) this syntax. When the switch was made to `makeDir.sync`, the `mode` integer wasn't wrapped in an `opts` object. The result is that `makeDir` uses its own default file mode when creating the config store.
