### PR TITLE
Do not create a file on read if it doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ class Configstore {
 			path.join('configstore', `${id}.json`);
 
 		this.path = path.join(configDir, pathPrefix);
-		this.all = Object.assign({}, defaults, this.all);
+		if (defaults) {
+			this.all = Object.assign({}, defaults, this.all);
+		}
 	}
 	get all() {
 		try {
@@ -30,7 +32,6 @@ class Configstore {
 		} catch (err) {
 			// Create dir if it doesn't exist
 			if (err.code === 'ENOENT') {
-				makeDir.sync(path.dirname(this.path), makeDirOptions);
 				return {};
 			}
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ class Configstore {
 		this.path = opts.configPath || path.join(configDir, pathPrefix);
 
 		if (defaults) {
-			this.all = Object.assign({}, defaults, this.all);
+			  this.all = Object.assign({}, defaults, this.all);
 		}
 	}
 

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ import Configstore from '.';
 const configstorePath = new Configstore('configstore-test').path;
 
 test.beforeEach(t => {
-	fs.unlinkSync(configstorePath);
+	cleanUpFile();
 	t.context.conf = new Configstore('configstore-test');
 });
 
@@ -109,6 +109,20 @@ test('support global namespace path option', t => {
 });
 
 test('ensure `.all` is always an object', t => {
-	fs.unlinkSync(configstorePath);
+	cleanUpFile();
 	t.notThrows(() => t.context.conf.get('foo'));
 });
+
+test('the store is NOT created until write', t => {
+	cleanUpFile();
+	const conf = new Configstore('configstore-test');
+	t.false(fs.existsSync(conf.path));
+	conf.set('foo', 'bar');
+	t.true(fs.existsSync(conf.path));
+});
+
+function cleanUpFile() {
+	if (fs.existsSync(configstorePath)) {
+		fs.unlinkSync(configstorePath);
+	}
+}


### PR DESCRIPTION
Fixes #56 

This change will only cause a config file to be created if there is something to create.
