### PR TITLE
Add `configPath` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ class Configstore {
 			path.join(id, 'config.json') :
 			path.join('configstore', `${id}.json`);
 
-		this.path = path.join(configDir, pathPrefix);
+		this.path = opts.configPath || path.join(configDir, pathPrefix);
 		this.all = Object.assign({}, defaults, this.all);
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -66,9 +66,11 @@ Store the config at `$CONFIG/package-name/config.json` instead of the default `$
 ##### configPath
 
 Type: `string`<br>
-Default: `undefined`
+Default: Automatic
 
-Set the path of the config file.  Overrides the `packageName` and `globalConfigPath` options.
+**Please don't use this option unless absolutely necessary and you know what you're doing.**
+
+Set the path of the config file. Overrides the `packageName` and `globalConfigPath` options.
 
 ### Instance
 

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,13 @@ Default: `false`
 
 Store the config at `$CONFIG/package-name/config.json` instead of the default `$CONFIG/configstore/package-name.json`. This is not recommended as you might end up conflicting with other tools, rendering the "without having to think" idea moot.
 
+##### configPath
+
+Type: `string`<br>
+Default: `undefined`
+
+Set the path of the config file.  Overrides the `packageName` and `globalConfigPath` options.
+
 ### Instance
 
 You can use [dot-notation](https://github.com/sindresorhus/dot-prop) in a `key` to access nested properties.

--- a/test.js
+++ b/test.js
@@ -104,13 +104,13 @@ test('use default value', t => {
 	t.is(conf.get('foo'), 'bar');
 });
 
-test('support global namespace path option', t => {
+test('support `globalConfigPath` option', t => {
 	const conf = new Configstore('configstore-test', {}, {globalConfigPath: true});
 	const regex = /configstore-test(\/|\\)config.json$/;
 	t.true(regex.test(conf.path));
 });
 
-test('support config path option', t => {
+test('support `configPath` option', t => {
 	const customPath = path.join(os.tmpdir(), 'configstore-custom-path', 'foo.json');
 	const conf = new Configstore('ignored-namespace', {}, {globalConfigPath: true, configPath: customPath});
 	const regex = /configstore-custom-path(\/|\\)foo.json$/;

--- a/test.js
+++ b/test.js
@@ -1,4 +1,6 @@
 import fs from 'fs';
+import path from 'path';
+import os from 'os';
 import {serial as test} from 'ava';
 import Configstore from '.';
 
@@ -105,6 +107,13 @@ test('use default value', t => {
 test('support global namespace path option', t => {
 	const conf = new Configstore('configstore-test', {}, {globalConfigPath: true});
 	const regex = /configstore-test(\/|\\)config.json$/;
+	t.true(regex.test(conf.path));
+});
+
+test('support config path option', t => {
+	const customPath = path.join(os.tmpdir(), 'configstore-custom-path', 'foo.json');
+	const conf = new Configstore('ignored-namespace', {}, {globalConfigPath: true, configPath: customPath});
+	const regex = /configstore-custom-path(\/|\\)foo.json$/;
 	t.true(regex.test(conf.path));
 });
 


### PR DESCRIPTION
It looks like https://github.com/yeoman/configstore/pull/37 didn’t quite land,  but I do want to see this option to some capacity.  My use case is that I want to force the config dir to be `~/.namespace` (I know, I know…), which could also be achieved a number of other ways (a `forceHomeDir` option?).  

Anyway, happy to go down other paths, or land this change.