### PR TITLE
feat: serde option to allow alternatives to JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 	},
 	"devDependencies": {
 		"ava": "*",
+		"js-yaml": "^3.12.0",
 		"xo": "*"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,39 @@ Default: Automatic
 
 Set the path of the config file. Overrides the `packageName` and `globalConfigPath` options.
 
+##### serde
+
+Type: `Object`<br>
+Default:
+
+```js
+{
+	serialize: function (value) {
+		return JSON.stringify(value, null, '\t');
+	},
+	deserialize: JSON.parse,
+	ext: 'json'
+}
+```
+
+Serialization, deserialization and file extension options. Defaults to JSON.
+
+Example using YAML:
+```js
+const yaml = require('js-yaml');
+const yamlOptions = {schema: yaml.JSON_SCHEMA};
+const serde = {
+	serialize: function (value) {
+		return yaml.safeDump(value, yamlOptions);
+	},
+	deserialize: function (value) {
+		return yaml.safeLoad(value, yamlOptions);
+	},
+	ext: 'yaml'
+};
+const conf = new ConfigStore('id', undefined, {serde});
+```
+
 ### Instance
 
 You can use [dot-notation](https://github.com/sindresorhus/dot-prop) in a `key` to access nested properties.


### PR DESCRIPTION
I'd like to use configstore with yaml serde.

I see one issue, which I did not address in this PR - the check for a SyntaxError clearing the file. Does that feature serve a meaningful purpose? It worries me that if I open a file to edit it, make a syntax mistake, run a program that reads the file, lose the entire contents!?