### PR TITLE
CVE-2020-8116 # Upgrade dot-prop package to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"save"
 	],
 	"dependencies": {
-		"dot-prop": "^5.1.0",
+		"dot-prop": "^5.2.0",
 		"graceful-fs": "^4.1.2",
 		"make-dir": "^3.0.0",
 		"unique-string": "^2.0.0",


### PR DESCRIPTION
- Upgrade dot-prop package to 5.2.0 which is not vulnerable to CVE-2020-8116 

More info: https://hackerone.com/reports/719856