### PR TITLE
build: use sindresorhus dot-prop legacy patch 4.2.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fs = require('graceful-fs');
 const makeDir = require('make-dir');
 const xdgBasedir = require('xdg-basedir');
 const writeFileAtomic = require('write-file-atomic');
-const dotProp = require('dot-prop-legacy');
+const dotProp = require('dot-prop');
 const uniqueString = require('unique-string');
 
 const configDir = xdgBasedir.config || path.join(os.tmpdir(), uniqueString());

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "save"
   ],
   "dependencies": {
-    "dot-prop-legacy": "^4.2.1",
+    "dot-prop": "^4.2.1",
     "graceful-fs": "^4.1.2",
     "make-dir": "^1.0.0",
     "unique-string": "^1.0.0",


### PR DESCRIPTION
Use the "official" [legacy patch](https://github.com/sindresorhus/dot-prop/tree/v4) of `dot-prop` that resolves CVE-2020-8116. 