### PR TITLE
Replace `make-dir` with `fs.mkdirSync`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
           - 14
           - 12
           - 10
-          - 8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const os = require('os');
 const fs = require('graceful-fs');
-const makeDir = require('make-dir');
 const xdgBasedir = require('xdg-basedir');
 const writeFileAtomic = require('write-file-atomic');
 const dotProp = require('dot-prop');
@@ -10,7 +9,7 @@ const uniqueString = require('unique-string');
 
 const configDirectory = xdgBasedir.config || path.join(os.tmpdir(), uniqueString());
 const permissionError = 'You don\'t have access to this file.';
-const makeDirOptions = {mode: 0o0700};
+const mkdirOptions = {mode: 0o0700, recursive: true};
 const writeFileOptions = {mode: 0o0600};
 
 class Configstore {
@@ -56,7 +55,7 @@ class Configstore {
 	set all(value) {
 		try {
 			// Make sure the folder exists as it could have been deleted in the meantime
-			makeDir.sync(path.dirname(this.path), makeDirOptions);
+			fs.mkdirSync(path.dirname(this.path), mkdirOptions);
 
 			writeFileAtomic.sync(this.path, JSON.stringify(value, undefined, '\t'), writeFileOptions);
 		} catch (error) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10.13"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -35,7 +35,6 @@
 	"dependencies": {
 		"dot-prop": "^5.2.0",
 		"graceful-fs": "^4.1.2",
-		"make-dir": "^3.0.0",
 		"unique-string": "^2.0.0",
 		"write-file-atomic": "^3.0.0",
 		"xdg-basedir": "^4.0.0"

--- a/test.js
+++ b/test.js
@@ -140,7 +140,7 @@ test('the store is NOT created until write', t => {
 	t.true(fs.existsSync(config.path));
 });
 
-test('ensure necessary sub directories are created', t => {
+test('ensure necessary sub-directories are created', t => {
 	const customPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'configstore-recursive-')), 'foo', 'bar', 'baz.json');
 	const config = new Configstore('ignored-namespace', undefined, {
 		globalConfigPath: true,

--- a/test.js
+++ b/test.js
@@ -139,3 +139,14 @@ test('the store is NOT created until write', t => {
 	config.set('foo', 'bar');
 	t.true(fs.existsSync(config.path));
 });
+
+test('ensure necessary sub directories are created', t => {
+	const customPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'configstore-recursive-')), 'foo', 'bar', 'baz.json');
+	const config = new Configstore('ignored-namespace', undefined, {
+		globalConfigPath: true,
+		configPath: customPath
+	});
+	t.false(fs.existsSync(config.path));
+	config.set('foo', 'bar');
+	t.true(fs.existsSync(config.path));
+});


### PR DESCRIPTION
Node.js 10 LTS introduced recursive fs.mkdirSync so that we can drop make-dir from dependencies.

Fixes https://github.com/yeoman/configstore/issues/75

BREAKING CHANGE: Requries Node.js 10 LTS+.