### PR TITLE
Add missing fs dependency in the example code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,8 +17,8 @@ $ npm install configstore
 ## Usage
 
 ```js
+import fs from 'node:fs';
 import Configstore from 'configstore';
-import fs from 'fs';
 
 const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ $ npm install configstore
 
 ```js
 import Configstore from 'configstore';
+import fs from 'fs';
 
 const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 


### PR DESCRIPTION
The `fs` module isn't included in the example code block. Running the example code directly will cause a reference error:

```sh
const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
                               ^

ReferenceError: fs is not defined
```