### PR TITLE
Require Node.js 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
-          - 12
+          - 16
+          - 18
+          - 19
+          - 20
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=16"
 	},
 	"scripts": {
 		"test": "xo && ava"


### PR DESCRIPTION
Hi @sindresorhus!

This is breaking change. Node.js 12 and 14 are [End Of Life](https://github.com/nodejs/release#release-schedule) (v14 in at 2023-04-30).

I updated the pipeline to use the current Node.js versions (16, 18, 19 and 20)