### PR TITLE
Bump minimum version to Node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
-          - 12
+          - 22
+          - 20
+          - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava"


### PR DESCRIPTION
The last bump was 3 years ago to Node 12 

https://github.com/yeoman/configstore/releases/tag/v6.0.0